### PR TITLE
[doas] doas stop

### DIFF
--- a/modules/doas.js
+++ b/modules/doas.js
@@ -65,7 +65,7 @@ module.exports = class doas {
                     embedFunction(action);
                 case 'stop': // doas stop 
                     const embed = new MessageEmbed()
-                        .setTitle("**Stop, Drop, and Role**")
+                        .setTitle("**Stop, Drop, and Roll**")
                         .setDescription("**Please drop the current discussion and move on, thanks!**")
                         .setThumbnail("https://i.imgur.com/HJoCgcw.png")
                     message.channel.send(embed);

--- a/modules/doas.js
+++ b/modules/doas.js
@@ -63,6 +63,11 @@ module.exports = class doas {
                     await message.guild.members.ban(member, reason);
                     message.channel.send(`Banned ${member}.`);
                     embedFunction(action);
+                case 'stop': // doas stop 
+                    const embed = new MessageEmbed()
+                        .setTitle("**Stop, Drop, and Role**")
+                        .setDescription("**Please drop the current discussion and move on, thanks!**")
+                    message.channel.send(embed);
 
                 default: // If there is no value to action, then return and send a message.
                     return message.channel.send("You must provide an argument")

--- a/modules/doas.js
+++ b/modules/doas.js
@@ -60,13 +60,14 @@ module.exports = class doas {
                 case 'ban': // Is it 'ban'?
                     if(!member) return message.channel.send("Who is being banned?");
                     if(!member.bannable) return message.channel.send("You cannot ban this user.");
-                    await message.guild.members.ban(member, reason);
+                    await message.guild.members.ban(member, reason);    
                     message.channel.send(`Banned ${member}.`);
                     embedFunction(action);
                 case 'stop': // doas stop 
                     const embed = new MessageEmbed()
                         .setTitle("**Stop, Drop, and Role**")
                         .setDescription("**Please drop the current discussion and move on, thanks!**")
+                        .setThumbnail("https://i.imgur.com/HJoCgcw.png")
                     message.channel.send(embed);
 
                 default: // If there is no value to action, then return and send a message.


### PR DESCRIPTION
I believe that when the topic is straying from the channel topic, there should be a passive-aggressive way of letting users know that they are being off-topic or disruptive. This command will help. Simply `!doas stop` and an embed will be sent telling them to stop!

![As such](https://cdn.discordapp.com/attachments/622973184735707148/751229050218872882/unknown.png)