### PR TITLE
[role & doas] fix some stuff

### DIFF
--- a/modules/doas.js
+++ b/modules/doas.js
@@ -66,7 +66,7 @@ module.exports = {
                         // You were passing a User object into the ban method, which won't work. Instead, we get the guildMember using guild.Member(member) and then use the ban() method with a reason
                         // in an options Object and it works!
                         member.forEach(x => x.ban({reason: reason}).catch(console.error).then(
-                            names.push(`**${x.user.tag}**`),
+                            names.push(`${x.user.tag}`),
                         ));
                         message.channel.send(`Banned ${names.join(', ')}.`);
                         embedFunction('banned', names);

--- a/modules/doas.js
+++ b/modules/doas.js
@@ -11,9 +11,9 @@ module.exports = {
                 let cUser = message.author;
                 let logChannel = bot.channels.cache.get(config.logChannelID);
                 let logEmbed = new Discord.MessageEmbed()
-                    .setDescription(`**${names.join(', ')} was ${action} by ${cUser}**`)
+                    .setDescription(`${names.join(', ')} **was ${action} by ${cUser}**`)
                     .setColor("#D00B00")
-                    .addField(`Reason`, reason)
+                    .addField(`Reason`, reason || 'Reason not provided.')
                     .setTimestamp(message.createdAt)
 
                 logChannel.send(logEmbed);
@@ -66,7 +66,7 @@ module.exports = {
                         // You were passing a User object into the ban method, which won't work. Instead, we get the guildMember using guild.Member(member) and then use the ban() method with a reason
                         // in an options Object and it works!
                         member.forEach(x => x.ban({reason: reason}).catch(console.error).then(
-                            names.push(`${x.user.tag}`),
+                            names.push(`**${x.user.tag}**`),
                         ));
                         message.channel.send(`Banned ${names.join(', ')}.`);
                         embedFunction('banned', names);

--- a/modules/role.js
+++ b/modules/role.js
@@ -9,11 +9,12 @@ module.exports = {
       role => role.name === `${roleName}`
     );
     
+    let whitelist = Object.keys(roleFile).slice(1)
+    
     switch (action) {
       case 'add':
         if (!roleName) return message.channel.send("You must supply a role name.");
         
-        let whitelist = Object.keys(roleFile).slice(1)
         let role = message.guild.roles.cache.find(role => role.name === roleName)
 
         if (!message.guild.roles.cache.find(role => role.name === roleName)) return message.channel.send("Role not found")
@@ -30,8 +31,7 @@ module.exports = {
       case 'remove':
         if (!roleName)
         return message.channel.send("You must supply a role name.");
-        var whitelist = Object.values(roleFile).slice(1)
-        
+
         if (!message.guild.roles.cache.find(role => role.name === roleName)) return message.channel.send("Role not found")
         if (!whitelist.includes(roleName)) return message.channel.send("That role is not self-assignable")
 

--- a/modules/role.js
+++ b/modules/role.js
@@ -13,12 +13,11 @@ module.exports = {
       case 'add':
         if (!roleName) return message.channel.send("You must supply a role name.");
         
-        var whitelist = Object.values(roleFile).slice(1)
+        let whitelist = Object.keys(roleFile).slice(1)
         let role = message.guild.roles.cache.find(role => role.name === roleName)
-        
+
         if (!message.guild.roles.cache.find(role => role.name === roleName)) return message.channel.send("Role not found")
         if (!whitelist.includes(roleName)) return message.channel.send("That role is not self-assignable")
-
         if (message.member.roles.cache.find(role => role.name === `${roleName}`)) {
           message.channel.send(`You are already in ${roleName}.`);
         } 


### PR DESCRIPTION
This is 2 PRs in one because I'm too lazy to make two PRs

## role
Currently, we are using the whitelist Object's values, however, this is the description field of the role configuration. The reason this won't work is that say you are to add spaces to a description and not as a role. This makes it impossible for the bot to understand, so the solution is to use the keys based on how the role configuration is laid out. 

Furthermore, we no long use `var`  to declare the whitelist. We now use `let` and only declare it once above the switch case.

## doas
The second thing in this PR is for the ban command in doas.js. We are bolding the tag and sending that to the embed function. This screws with markdown making it not work. I fixed that by not bolding the entirety of the description. I don't bold the names. The names are already bolded in the command. 

Also, without a reason, the bot will throw an error about sending an empty message due to the embed's reason field not being complete. Should a reason not be given, a placeholder will appear instead. The placeholder is `Reason not provided.` 